### PR TITLE
Add TipKit guidance across mapping features

### DIFF
--- a/src/iOS/AppDelegate.swift
+++ b/src/iOS/AppDelegate.swift
@@ -112,10 +112,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			UserPrefs.shared.copyUserDefaultsToUbiquitousStore()
 		}
 
-		// access the current OSM server to force capabilities download
-		_ = OSM_SERVER
-		return true
-	}
+                // access the current OSM server to force capabilities download
+                _ = OSM_SERVER
+                TipCoordinator.shared.configureIfNeeded()
+                return true
+        }
 
 	static let appName: String = Bundle.main.infoDictionary?["CFBundleDisplayName"] as! String
 

--- a/src/iOS/DisplaySettings/DisplayViewController.swift
+++ b/src/iOS/DisplaySettings/DisplayViewController.swift
@@ -99,10 +99,10 @@ class DisplayViewController: UITableViewController {
 		addButtonPosition.setTitle(title, for: .normal)
 	}
 
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
+        override func viewWillAppear(_ animated: Bool) {
+                super.viewWillAppear(animated)
 
-		guard let mapView = AppDelegate.shared.mapView else { return }
+                guard let mapView = AppDelegate.shared.mapView else { return }
 
 		// becoming visible the first time
 		navigationController?.isNavigationBarHidden = false
@@ -116,8 +116,16 @@ class DisplayViewController: UITableViewController {
 		turnRestrictionSwitch.isOn = mapView.enableTurnRestriction
 		objectFiltersSwitch.isOn = mapView.editorLayer.objectFilters.enableObjectFilters
 
-		setButtonLayoutTitle()
-	}
+                setButtonLayoutTitle()
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+                super.viewDidAppear(animated)
+
+                TipCoordinator.shared.showGpxTip(from: self, sourceView: gpxLoggingSwitch)
+                TipCoordinator.shared.showQuestsTip(from: self, sourceView: questsSwitch)
+                TipCoordinator.shared.showDataOverlayTip(from: self, sourceView: dataOverlaySwitch)
+        }
 
 	override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell,
 	                        forRowAt indexPath: IndexPath)

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02008650265B25DC008F37DD /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028816A2265AD9D100C30EA2 /* Database.swift */; };
+               0354E77C7C654DAB8DF44D4C /* TipCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB35F62233DB4E1FA64D3CD7 /* TipCoordinator.swift */; };
+               02008650265B25DC008F37DD /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028816A2265AD9D100C30EA2 /* Database.swift */; };
 		0200C1C22703B42600A79804 /* LocationParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0200C1C12703B42600A79804 /* LocationParser.swift */; };
 		0200FECD2908B0EB002C3F94 /* GeoJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0200FECC2908B0EB002C3F94 /* GeoJSON.swift */; };
 		0202C5FE2E3BFD7500649F26 /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202C5FD2E3BFD7500649F26 /* CustomSegmentedControl.swift */; };
@@ -349,7 +350,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0200C1C12703B42600A79804 /* LocationParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocationParser.swift; path = ../../Shared/LocationParser.swift; sourceTree = "<group>"; };
+               CB35F62233DB4E1FA64D3CD7 /* TipCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipCoordinator.swift; sourceTree = "<group>"; };
+               0200C1C12703B42600A79804 /* LocationParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocationParser.swift; path = ../../Shared/LocationParser.swift; sourceTree = "<group>"; };
 		0200FECC2908B0EB002C3F94 /* GeoJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoJSON.swift; sourceTree = "<group>"; };
 		0202C5FD2E3BFD7500649F26 /* CustomSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSegmentedControl.swift; sourceTree = "<group>"; };
 		0202C5FF2E3C348400649F26 /* ButtonClosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ButtonClosure.swift; path = ../../Shared/Utility/ButtonClosure.swift; sourceTree = "<group>"; };
@@ -814,12 +816,13 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		02ACBA3916713CCB00BB4414 /* Go Map! */ = {
-			isa = PBXGroup;
-			children = (
-				C3D096AB263D48F700E3B129 /* AppDelegate.swift */,
-				ED56E5B226026541000B368C /* BingMetadataViewController.swift */,
-				02F0297A2BFAFF2E002F7956 /* DataOverlays */,
+               02ACBA3916713CCB00BB4414 /* Go Map! */ = {
+                       isa = PBXGroup;
+                       children = (
+                               C3D096AB263D48F700E3B129 /* AppDelegate.swift */,
+                               ED56E5B226026541000B368C /* BingMetadataViewController.swift */,
+                               DACC8F43B3AF433997A49CB9 /* Tips */,
+                               02F0297A2BFAFF2E002F7956 /* DataOverlays */,
 				64D74BF02253DF39004FFD20 /* Direction */,
 				0244399629CA9A28009FC2D0 /* DisplaySettings */,
 				02E9ABBE2BA1502600F0EF69 /* GoogleMaps.secret */,
@@ -846,10 +849,18 @@
 				022114FB2E6CDCF800D76061 /* Turn Restrictions */,
 				647C150D24268DB7008A9366 /* Upload */,
 			);
-			name = "Go Map!";
-			sourceTree = "<group>";
-		};
-		02ACBA3A16713CCB00BB4414 /* Supporting Files */ = {
+                       name = "Go Map!";
+                       sourceTree = "<group>";
+               };
+               DACC8F43B3AF433997A49CB9 /* Tips */ = {
+                       isa = PBXGroup;
+                       children = (
+                               CB35F62233DB4E1FA64D3CD7 /* TipCoordinator.swift */,
+                       );
+                       path = Tips;
+                       sourceTree = "<group>";
+               };
+               02ACBA3A16713CCB00BB4414 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
 				02AFBF232458C1E700BE43F4 /* BingPlaceholderImage.png */,
@@ -1588,9 +1599,10 @@
 				024909CB267D99190027E531 /* OsmDownloader.swift in Sources */,
 				02696CD52B8EF19400AB70B6 /* HealthKitRoutes.swift in Sources */,
 				02A123EA264C8BA3005638C1 /* TileServerList.swift in Sources */,
-				02CBF3CC2BE8655D000DE2AD /* GpxTrackAttributes.swift in Sources */,
-				C3D096AC263D48F700E3B129 /* AppDelegate.swift in Sources */,
-				023320A22BE07B2000E3311A /* DataOverlayLayer.swift in Sources */,
+                                02CBF3CC2BE8655D000DE2AD /* GpxTrackAttributes.swift in Sources */,
+                                C3D096AC263D48F700E3B129 /* AppDelegate.swift in Sources */,
+                                0354E77C7C654DAB8DF44D4C /* TipCoordinator.swift in Sources */,
+                                023320A22BE07B2000E3311A /* DataOverlayLayer.swift in Sources */,
 				02F2449A264F635800C42E41 /* PathUtil.swift in Sources */,
 				C341E1532639DECC0022E983 /* WikiPage.swift in Sources */,
 				02B5669D294F9D7E00710632 /* MagnifyingGlass.swift in Sources */,

--- a/src/iOS/MainViewController.swift
+++ b/src/iOS/MainViewController.swift
@@ -151,12 +151,22 @@ class MainViewController: UIViewController, UIActionSheetDelegate, UIGestureReco
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
 #if USER_MOVABLE_BUTTONS
-		makeMovableButtons()
+                makeMovableButtons()
 #endif
 
-		// this is necessary because we need the frame to be set on the view before we set the previous lat/lon for the view
-		mapView.viewDidAppear()
-	}
+                // this is necessary because we need the frame to be set on the view before we set the previous lat/lon for the view
+                mapView.viewDidAppear()
+
+                TipCoordinator.shared.showLocationTip(from: self, sourceView: locationButton)
+                if let compassButton = mapView.compassButton {
+                        TipCoordinator.shared.showOrientationTip(from: self, sourceView: compassButton)
+                }
+                TipCoordinator.shared.showSearchTip(from: self, sourceView: searchButton)
+                TipCoordinator.shared.showMapLayersTip(from: self, sourceView: displayButton)
+                if let addButton = mapView.addNodeButton {
+                        TipCoordinator.shared.showAddButtonTip(from: self, sourceView: addButton)
+                }
+        }
 
 	func setupAccessibility() {
 		locationButton.accessibilityIdentifier = "location_button"

--- a/src/iOS/Settings/AdvancedSettingsViewController.swift
+++ b/src/iOS/Settings/AdvancedSettingsViewController.swift
@@ -36,18 +36,26 @@ class AdvancedSettingsViewController: UITableViewController {
 		sender.resignFirstResponder()
 	}
 
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
-		let appDelegate = AppDelegate.shared
-		hostname.text = OSM_SERVER.apiURL
-		originalHostname = hostname.text
+        override func viewWillAppear(_ animated: Bool) {
+                super.viewWillAppear(animated)
+                let appDelegate = AppDelegate.shared
+                hostname.text = OSM_SERVER.apiURL
+                originalHostname = hostname.text
 
 		let app = UIApplication.shared as! MyApplication
 		switchFPS.isOn = appDelegate.mapView.automatedFramerateTestActive
 		switchTouches.isOn = app.showTouchCircles
 
-		switchMaxFPS.isOn = UserPrefs.shared.maximizeFrameRate.value ?? false
-	}
+                switchMaxFPS.isOn = UserPrefs.shared.maximizeFrameRate.value ?? false
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+                super.viewDidAppear(animated)
+
+                if let button = hostnameButton {
+                        TipCoordinator.shared.showAlternateServerTip(from: self, sourceView: button)
+                }
+        }
 
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)

--- a/src/iOS/Tips/TipCoordinator.swift
+++ b/src/iOS/Tips/TipCoordinator.swift
@@ -1,0 +1,325 @@
+import Foundation
+import SwiftUI
+import TipKit
+import UIKit
+
+final class TipCoordinator {
+        static let shared = TipCoordinator()
+
+        private var isConfigured = false
+        private var tipStoreStorage: Any?
+
+        private init() {}
+
+        func configureIfNeeded() {
+                guard #available(iOS 17.0, *) else { return }
+                guard !isConfigured else { return }
+
+                let store = tipStore
+                do {
+                        try Tips.configure(store.allTips)
+                        isConfigured = true
+                } catch {
+                        NSLog("TipKit configuration failed: %@", error.localizedDescription)
+                }
+        }
+
+        func showLocationTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.locationButton, from: sourceView, in: controller, arrow: .down)
+        }
+
+        func showOrientationTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.orientationButton, from: sourceView, in: controller, arrow: .down)
+        }
+
+        func showSearchTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.searchButton, from: sourceView, in: controller, arrow: .down)
+        }
+
+        func showMapLayersTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.mapLayersButton, from: sourceView, in: controller, arrow: .down)
+        }
+
+        func showAddButtonTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.addButton, from: sourceView, in: controller, arrow: .down)
+        }
+
+        func showGpxTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.gpxTraces, from: sourceView, in: controller)
+        }
+
+        func showQuestsTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.quests, from: sourceView, in: controller)
+        }
+
+        func showDataOverlayTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.dataLayers, from: sourceView, in: controller)
+        }
+
+        func showAlternateServerTip(from controller: UIViewController, sourceView: UIView) {
+                guard #available(iOS 17.0, *) else { return }
+                configureIfNeeded()
+                present(tipStore.alternateServers, from: sourceView, in: controller)
+        }
+
+        @available(iOS 17.0, *)
+        private var tipStore: AppTipStore {
+                if let store = tipStoreStorage as? AppTipStore {
+                        return store
+                }
+                let store = AppTipStore()
+                tipStoreStorage = store
+                return store
+        }
+
+        @available(iOS 17.0, *)
+        private func present<T: Tip>(_ tip: T,
+                                     from sourceView: UIView,
+                                     in controller: UIViewController,
+                                     arrow: UIPopoverArrowDirection = .any)
+        {
+                guard sourceView.window != nil else { return }
+                Task {
+                        if await tip.shouldDisplay {
+                                await schedulePresentation(tip, from: sourceView, in: controller, arrow: arrow)
+                        }
+                }
+        }
+
+        @available(iOS 17.0, *)
+        @MainActor
+        private func schedulePresentation<T: Tip>(_ tip: T,
+                                                  from sourceView: UIView,
+                                                  in controller: UIViewController,
+                                                  arrow: UIPopoverArrowDirection) async
+        {
+                guard controller.viewIfLoaded?.window != nil else { return }
+                guard sourceView.window != nil else { return }
+
+                if controller.presentedViewController != nil {
+                        try? await Task.sleep(nanoseconds: 600_000_000)
+                        await schedulePresentation(tip, from: sourceView, in: controller, arrow: arrow)
+                        return
+                }
+
+                let tipController = TipViewController(tip)
+                tipController.sourceView = sourceView
+                tipController.sourceRect = sourceView.bounds
+                tipController.permittedArrowDirections = arrow
+                controller.present(tipController, animated: true)
+        }
+}
+
+@available(iOS 17.0, *)
+private struct AppTipStore {
+        let locationButton = LocationButtonTip()
+        let orientationButton = OrientationButtonTip()
+        let searchButton = SearchButtonTip()
+        let mapLayersButton = MapLayersTip()
+        let addButton = AddButtonTip()
+        let gpxTraces = GpxTraceTip()
+        let quests = QuestsTip()
+        let dataLayers = DataLayersTip()
+        let alternateServers = AlternateServerTip()
+
+        var allTips: [any Tip] {
+                [
+                        locationButton,
+                        orientationButton,
+                        searchButton,
+                        mapLayersButton,
+                        addButton,
+                        gpxTraces,
+                        quests,
+                        dataLayers,
+                        alternateServers
+                ]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct LocationButtonTip: Tip {
+        var title: Text {
+                Text("Re-center the map")
+        }
+
+        var message: Text? {
+                Text("Tap once to jump to your location and again to follow your heading.")
+        }
+
+        var image: Image? {
+                Image(systemName: "location.circle")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct OrientationButtonTip: Tip {
+        var title: Text {
+                Text("Stay oriented")
+        }
+
+        var message: Text? {
+                Text("Use the compass to switch between north-up and heading-up views.")
+        }
+
+        var image: Image? {
+                Image(systemName: "location.north.line")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct SearchButtonTip: Tip {
+        var title: Text {
+                Text("Find places quickly")
+        }
+
+        var message: Text? {
+                Text("Search for addresses, places, and presets without leaving the map.")
+        }
+
+        var image: Image? {
+                Image(systemName: "magnifyingglass")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct MapLayersTip: Tip {
+        var title: Text {
+                Text("Switch map layers")
+        }
+
+        var message: Text? {
+                Text("Tap for display options or long-press to pick recent imagery.")
+        }
+
+        var image: Image? {
+                Image(systemName: "square.stack.3d.up")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct AddButtonTip: Tip {
+        var title: Text {
+                Text("Add features faster")
+        }
+
+        var message: Text? {
+                Text("Tap to add at the crosshairs or drag and long-press for precise placement.")
+        }
+
+        var image: Image? {
+                Image(systemName: "plus.circle")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct GpxTraceTip: Tip {
+        var title: Text {
+                Text("Record GPX traces")
+        }
+
+        var message: Text? {
+                Text("Keep the switch on to capture or review your GPS tracks while you map.")
+        }
+
+        var image: Image? {
+                Image(systemName: "map")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct QuestsTip: Tip {
+        var title: Text {
+                Text("Tackle quests")
+        }
+
+        var message: Text? {
+                Text("Show quests to discover nearby tasks contributed by the community.")
+        }
+
+        var image: Image? {
+                Image(systemName: "flag")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct DataLayersTip: Tip {
+        var title: Text {
+                Text("Overlay more data")
+        }
+
+        var message: Text? {
+                Text("Enable data layers to compare third-party maps and QA overlays while editing.")
+        }
+
+        var image: Image? {
+                Image(systemName: "square.grid.3x2")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}
+
+@available(iOS 17.0, *)
+private struct AlternateServerTip: Tip {
+        var title: Text {
+                Text("Map beyond OSM")
+        }
+
+        var message: Text? {
+                Text("Pick OpenHistoricalMap or OpenGeofiction to contribute to other communities.")
+        }
+
+        var image: Image? {
+                Image(systemName: "globe")
+        }
+
+        var options: [TipOption] {
+                [Tips.MaxDisplayCount(1)]
+        }
+}


### PR DESCRIPTION
## Summary
- add a shared TipCoordinator that configures TipKit and defines tips for frequently used controls
- surface contextual tips on the main map, display options, and advanced server selection screens
- initialize TipKit during app launch so the tips are ready when views appear

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf52c803e4832a97648910eb191c33